### PR TITLE
Use var instead of hardcoded storage pool path

### DIFF
--- a/roles/create_vm_kvm/tasks/main.yml
+++ b/roles/create_vm_kvm/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
-- name: Get pool info
+- name: Get storage pool info
   virt_pool:
     command: info
   register: pools
 
-- name: Get {{ storage_pool }} info
+- name: Get {{ storage_pool }} storage details
   set_fact:
-    storage_path: "{{ pools|json_query('pools.KVM.path') }}"
+    storage_path: "{{ pools|json_query(storage_pool_jsonpath) }}"
 
 - name: Create the cloud-init config drive path
   file:

--- a/roles/create_vm_kvm/vars/main.yml
+++ b/roles/create_vm_kvm/vars/main.yml
@@ -1,0 +1,2 @@
+---
+storage_pool_jsonpath: "pools.{{ storage_pool }}.path"

--- a/roles/destroy_vm_kvm/defaults/main.yml
+++ b/roles/destroy_vm_kvm/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+storage_pool: KVM

--- a/roles/destroy_vm_kvm/tasks/destroy_vm.yml
+++ b/roles/destroy_vm_kvm/tasks/destroy_vm.yml
@@ -19,7 +19,7 @@
 
 - name: Get {{ storage_pool }} info
   set_fact:
-    storage_path: "{{ pools|json_query('pools.KVM.path') }}"
+    storage_path: "{{ pools|json_query(storage_pool_jsonpath) }}"
 
 - name: Delete the volumes and cloud-init config drive path
   file:

--- a/roles/destroy_vm_kvm/vars/main.yml
+++ b/roles/destroy_vm_kvm/vars/main.yml
@@ -1,0 +1,2 @@
+---
+storage_pool_jsonpath: "pools.{{ storage_pool }}.path"


### PR DESCRIPTION
There is a `storage_pool` variable, but the task that finds details of the pool had a hardcoded json path of `pool.KVM.path`.

This adds a variable `storage_pool_jsonpath` for that path derived from `storage_pool`